### PR TITLE
Remove kkn.fi import and move package description to base62.go

### DIFF
--- a/base62.go
+++ b/base62.go
@@ -1,4 +1,5 @@
-package base62 // import "kkn.fi/base62"
+// Package base62 implements base62 encoder and decoder.
+package base62
 
 import (
 	"fmt"

--- a/doc.go
+++ b/doc.go
@@ -1,2 +1,0 @@
-// Package base62 implements base62 encoder and decoder.
-package base62 // import "kkn.fi/base62"


### PR DESCRIPTION
The kkn.fi import does not resolve, so I have removed it allowing the library to imported. I also removed doc.go and moved the package description to base62.go